### PR TITLE
Fix no playback after seeking

### DIFF
--- a/karaokechan.py
+++ b/karaokechan.py
@@ -11,6 +11,7 @@ import kchan.lyrics as lyrics
 import kchan.widgets as kcw
 import kchan.timedtext as timedtext
 import kchan.formats.lyrics3v2 as lyrics3v2
+from kchan.pygamemediactrl import PyGameMediaCtrl
 
 
 def handler(fn):
@@ -45,7 +46,7 @@ class KaraokePlayer(wx.Frame):
         wx.Frame.__init__(self, *args, **kwargs)
 
         # media widget
-        self.player = wxm.MediaCtrl(self)
+        self.player = PyGameMediaCtrl(self)
         self.Bind(wxm.EVT_MEDIA_STATECHANGED, self.OnPlayer, self.player)
 
         # lyrics viewer
@@ -200,7 +201,7 @@ class KaraokePlayer(wx.Frame):
         self.UpdateTime()
 
         if self.player.GetState() == wxm.MEDIASTATE_PLAYING:
-            self.timer.Start(milliseconds=100)
+            wx.CallAfter(self.timer.Start, milliseconds=100)
             self.playPauseButton.SetValue(True)
 
             if self.editMode:

--- a/kchan/pygamemediactrl.py
+++ b/kchan/pygamemediactrl.py
@@ -1,0 +1,81 @@
+import audioread
+from pygame import mixer
+music = mixer.music
+import time
+import wx
+import wx.media as wxm
+
+
+PAUSED = wxm.MEDIASTATE_PAUSED
+PLAYING = wxm.MEDIASTATE_PLAYING
+
+
+class PyGameMediaCtrl(wx.Control):
+    def __init__(self, *args, **kwargs):
+        super(PyGameMediaCtrl, self).__init__(*args, **kwargs)
+        mixer.init()
+
+    def Load(self, filename):
+        with audioread.audio_open(filename) as f:
+            self.duration = int(f.duration * 1000)
+            self.samplerate = f.samplerate
+            self.channels = f.channels
+        mixer.quit()
+        mixer.init(frequency=self.samplerate, channels=self.channels)
+        music.load(filename)
+        self.pos = 0
+
+    def Length(self):
+        return self.duration
+
+    def Tell(self):
+        if music.get_busy():
+            return self.pos + music.get_pos()
+        else:
+            return self.pos
+
+    def GetState(self):
+        return PLAYING if music.get_busy() else PAUSED
+
+    def state_change(self):
+        wx.PostEvent(self.GetEventHandler(),
+                     wx.PyCommandEvent(wxm.EVT_MEDIA_STATECHANGED.typeId,
+                                       self.GetId()))
+
+    def Pause(self):
+        if music.get_busy():
+            self.pos = self.Tell()
+            music.stop()
+            wx.CallAfter(self.state_change)
+
+    def Stop(self):
+        if music.get_busy():
+            self.pos = 0
+            music.stop()
+            wx.CallAfter(self.state_change)
+
+    def Play(self):
+        if not music.get_busy():
+            music.play(0, self.pos / 1000.0)
+            wx.CallAfter(self.state_change)
+
+    def GetVolume(self):
+        return music.get_volume()
+
+    def SetVolume(self, vol):
+        music.set_volume(vol)
+
+    def GetPlaybackRate(self):
+        return self.samplerate
+
+    def Seek(self, pos):
+        self.pos = pos
+        if music.get_busy():
+            music.stop()
+            music.play(0, pos / 1000.0)
+
+    def GetBestSize(self):
+        return (0, 0)
+
+if __name__ == '__main__':
+    main()

--- a/kchan/widgets.py
+++ b/kchan/widgets.py
@@ -74,9 +74,10 @@ class LyricsCtrl(wx.TextCtrl):
             self.lastPhrase = (phraseStart, phraseEnd)
 
         if endTime is not None:
-            self.phraseTimer.Start((endTime - playTime) * 10, wx.TIMER_ONE_SHOT)
+            wx.CallAfter(self.phraseTimer.Start, (endTime - playTime) * 10, wx.TIMER_ONE_SHOT)
 
     def OnPlayer(self, evt):
+        print('hi')
         if self.player.GetState() == wxm.MEDIASTATE_PLAYING:
             self.OnPhraseTimer(None)
         else:


### PR DESCRIPTION
Allows seeking through the song at any point, though at the cost of
adding pygame and audioread as dependencies, as well as abandoning video
playback and introducing some instability due to wxPython interacting
strangely with pygame's threading.

Fixes #1.